### PR TITLE
redirect jp address to ja

### DIFF
--- a/jp.md
+++ b/jp.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /jp
+redir_to: /ja/
+---


### PR DESCRIPTION
thanks to @davidkazuhiro we updated jp -> ja in https://github.com/tanda/wedding/pull/18.

However, because we use the /jp address on our invitations and I don't feel like sending a new QR Code, we can just use a redirect in order to get to the right address(/ja)